### PR TITLE
Tests can now be skipped at runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.testobject.extras.appium</groupId>
     <artifactId>appium-java-api</artifactId>
-    <version>0.0.11</version>
+    <version>0.0.12-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/testobject/appium/common/AppiumResource.java
+++ b/src/main/java/org/testobject/appium/common/AppiumResource.java
@@ -25,6 +25,14 @@ public class AppiumResource {
 				.put(Collections.singletonMap("passed", passed));
 	}
 
+	public void updateTestReportStatusToSkipped(SessionId sessionId) {
+		client
+				.path("session")
+				.path(sessionId.toString())
+				.path("skiptest").type(MediaType.APPLICATION_JSON_TYPE)
+				.put();
+	}
+
 	public void updateTestReportName(SessionId sessionId, String suiteName, String testName) {
 		Map<String, String> values = new HashMap<String, String>();
 		values.put("suiteName", suiteName);

--- a/src/main/java/org/testobject/appium/common/AppiumSuiteReportResource.java
+++ b/src/main/java/org/testobject/appium/common/AppiumSuiteReportResource.java
@@ -45,4 +45,14 @@ public class AppiumSuiteReportResource {
 				.put(TestReport.class, testResult);
 	}
 
+	public TestReport skipTestReport(long suiteId, SuiteReport.Id suiteReportId, TestReport.Id testReportId) {
+		return client
+				.path("suites").path(Long.toString(suiteId))
+				.path("reports").path(Long.toString(suiteReportId.value()))
+				.path("results").path(Integer.toString(testReportId.value()))
+				.path("skip")
+				.type(MediaType.APPLICATION_JSON_TYPE)
+				.put(TestReport.class, new TestResult(true));
+	}
+
 }

--- a/src/test/java/org/testobject/appium/junit/CalculatorTest.java
+++ b/src/test/java/org/testobject/appium/junit/CalculatorTest.java
@@ -2,8 +2,6 @@ package org.testobject.appium.junit;
 
 import io.appium.java_client.MobileBy;
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.remote.MobileCapabilityType;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;


### PR DESCRIPTION
Instead of passing a non-boolean test status to the backend, we call separate methods that take care of setting the status properly for skipped tests. This approach is safer from the point of view of backwards compatibility.
